### PR TITLE
Fix for DM message not triggering without greeting

### DIFF
--- a/src/SlackInterface.js
+++ b/src/SlackInterface.js
@@ -82,6 +82,9 @@ var handleRtmMessage = function(message) {
                 rtm.sendMessage("No need to include initial commands in Direct Messages. Please enter command.", message.channel);
             }
         }
+        else {
+            parseCommand(message);
+        }
     } 
     
 


### PR DESCRIPTION
Fixing an issue where jarvis would not respond to direct messages without a greeting.